### PR TITLE
Update queue timestamp on manual runs

### DIFF
--- a/process_queue.php
+++ b/process_queue.php
@@ -4,6 +4,7 @@
 
 require_once 'config.php';
 require_once 'fetch_page_content.php';
+require_once 'queue_helpers.php';
 
 // Zmienna globalna do określania trybu (CLI vs WWW)
 $is_cli_mode = php_sapi_name() === 'cli';
@@ -421,6 +422,7 @@ if (!$is_cli_mode) {
 logMessage("Starting queue processor. Mode: " . ($is_cli_mode ? "CLI" : "WWW (Manual Trigger)"));
 
 $pdo = getDbConnection();
+updateLastRunTimestamp($pdo);
 $api_key = getGeminiApiKey();
 $processing_delay_minutes = getProcessingDelayMinutes();
 

--- a/process_queue_cli.php
+++ b/process_queue_cli.php
@@ -22,6 +22,7 @@ if (!file_exists($app_root . '/config.php')) {
 }
 
 require_once $app_root . '/config.php';
+require_once $app_root . '/queue_helpers.php';
 
 /**
  * Loguje wiadomość do pliku i konsoli
@@ -42,21 +43,6 @@ function logMessage($message, $type = 'info') {
     file_put_contents($log_file, $log_entry, FILE_APPEND | LOCK_EX);
 }
 
-/**
- * Zapisuje timestamp ostatniego uruchomienia procesora
- */
-function updateLastRunTimestamp($pdo) {
-    try {
-        $stmt = $pdo->prepare("
-            INSERT INTO settings (setting_key, setting_value) 
-            VALUES ('last_queue_run', NOW()) 
-            ON DUPLICATE KEY UPDATE setting_value = NOW()
-        ");
-        $stmt->execute();
-    } catch (Exception $e) {
-        logMessage("Failed to update last run timestamp: " . $e->getMessage(), 'error');
-    }
-}
 
 /**
  * Pobiera klucz API Gemini

--- a/queue_helpers.php
+++ b/queue_helpers.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Utility helpers for queue processing
+ */
+
+/**
+ * Updates timestamp of the last queue processor run
+ *
+ * @param PDO $pdo Database connection
+ */
+function updateLastRunTimestamp(PDO $pdo) {
+    try {
+        $stmt = $pdo->prepare(
+            "INSERT INTO settings (setting_key, setting_value)
+            VALUES ('last_queue_run', NOW())
+            ON DUPLICATE KEY UPDATE setting_value = NOW()"
+        );
+        $stmt->execute();
+    } catch (Exception $e) {
+        // Assumes logMessage is defined by the including script
+        if (function_exists('logMessage')) {
+            logMessage('Failed to update last run timestamp: ' . $e->getMessage(), 'error');
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- extract `updateLastRunTimestamp` into `queue_helpers.php`
- import the helper in CLI and web queue processors
- update the last run timestamp when `process_queue.php` starts

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507674ab8c83338ffba2a076b0dc07