### PR TITLE
Add Anthropic API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Provide them either as environment variables or by creating a `config.local.php`
 - `DB_USER` – database user
 - `DB_PASS` – database password
 - `GEMINI_API_KEY` – API key used for requests to the Google Gemini API
+- `ANTHROPIC_API_KEY` – API key used for Anthropic Claude
 
 Example `config.local.php`:
 
@@ -20,6 +21,7 @@ define('DB_NAME', 'my_db');
 define('DB_USER', 'my_user');
 define('DB_PASS', 'secret');
 define('GEMINI_API_KEY', 'your-api-key');
+define('ANTHROPIC_API_KEY', 'your-anthropic-key');
 ```
 
 This file should **not** be committed to version control.

--- a/admin_settings.php
+++ b/admin_settings.php
@@ -18,12 +18,17 @@ if ($_POST) {
     switch ($action) {
         case 'save_settings':
             $gemini_api_key = trim($_POST['gemini_api_key']);
+            $anthropic_api_key = trim($_POST['anthropic_api_key']);
             $processing_delay = intval($_POST['processing_delay_minutes']);
             
             try {
                 // Zapisz klucz API Gemini
                 $stmt = $pdo->prepare("INSERT INTO settings (setting_key, setting_value) VALUES ('gemini_api_key', ?) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)");
                 $stmt->execute([$gemini_api_key]);
+
+                // Zapisz klucz API Anthropic Claude
+                $stmt = $pdo->prepare("INSERT INTO settings (setting_key, setting_value) VALUES ('anthropic_api_key', ?) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)");
+                $stmt->execute([$anthropic_api_key]);
                 
                 // Zapisz opóźnienie przetwarzania
                 $stmt = $pdo->prepare("INSERT INTO settings (setting_key, setting_value) VALUES ('processing_delay_minutes', ?) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)");
@@ -265,12 +270,17 @@ $language_models = $stmt->fetchAll();
                                     <input type="hidden" name="action" value="save_settings">
                                     <div class="mb-3">
                                         <label for="gemini_api_key" class="form-label">Klucz API Google Gemini *</label>
-                                        <input type="password" class="form-control" id="gemini_api_key" name="gemini_api_key" 
+                                        <input type="password" class="form-control" id="gemini_api_key" name="gemini_api_key"
                                                value="<?= htmlspecialchars($settings['gemini_api_key'] ?? '') ?>" required>
                                         <div class="form-text">
-                                            Klucz API potrzebny do generowania treści. Możesz go uzyskać w 
+                                            Klucz API potrzebny do generowania treści. Możesz go uzyskać w
                                             <a href="https://makersuite.google.com/app/apikey" target="_blank">Google AI Studio</a>.
                                         </div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="anthropic_api_key" class="form-label">Klucz API Anthropic Claude</label>
+                                        <input type="password" class="form-control" id="anthropic_api_key" name="anthropic_api_key"
+                                               value="<?= htmlspecialchars($settings['anthropic_api_key'] ?? '') ?>">
                                     </div>
                                     
                                     <div class="mb-3">

--- a/install.php
+++ b/install.php
@@ -20,6 +20,7 @@ if ($_POST) {
     $admin_email = $_POST['admin_email'];
     $admin_password = $_POST['admin_password'];
     $gemini_api_key = trim($_POST['gemini_api_key']);
+    $anthropic_api_key = trim($_POST['anthropic_api_key']);
     
     try {
         // Połącz z bazą danych
@@ -342,6 +343,12 @@ Usuń wszystkie znaki nowej linii (\n, \n\n).';
             $stmt = $pdo->prepare("INSERT INTO settings (setting_key, setting_value) VALUES ('gemini_api_key', ?)");
             $stmt->execute([$gemini_api_key]);
         }
+
+        // Zapisz klucz API Anthropic Claude
+        if (!empty($anthropic_api_key)) {
+            $stmt = $pdo->prepare("INSERT INTO settings (setting_key, setting_value) VALUES ('anthropic_api_key', ?)");
+            $stmt->execute([$anthropic_api_key]);
+        }
         
         // Dodaj domyślne ustawienia
         $stmt = $pdo->prepare("INSERT INTO settings (setting_key, setting_value) VALUES ('processing_delay_minutes', '1')");
@@ -458,10 +465,14 @@ function getDbConnection() {
                                 <label for="gemini_api_key" class="form-label">Klucz API Google Gemini</label>
                                 <input type="password" class="form-control" id="gemini_api_key" name="gemini_api_key">
                                 <div class="form-text">
-                                    Klucz API potrzebny do generowania treści. Możesz go uzyskać w 
+                                    Klucz API potrzebny do generowania treści. Możesz go uzyskać w
                                     <a href="https://makersuite.google.com/app/apikey" target="_blank">Google AI Studio</a>.
                                     Możesz też dodać go później w ustawieniach.
                                 </div>
+                            </div>
+                            <div class="mb-3">
+                                <label for="anthropic_api_key" class="form-label">Klucz API Anthropic Claude</label>
+                                <input type="password" class="form-control" id="anthropic_api_key" name="anthropic_api_key">
                             </div>
                             
                             <button type="submit" class="btn btn-primary">Zainstaluj</button>


### PR DESCRIPTION
## Summary
- extend installer to save `anthropic_api_key`
- allow configuring the new key in the admin settings
- document `ANTHROPIC_API_KEY` in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68552a10318083339d78a522af2eb60c