### PR TITLE
Add SSL verification flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Provide them either as environment variables or by creating a `config.local.php`
 - `DB_PASS` – database password
 - `GEMINI_API_KEY` – API key used for requests to the Google Gemini API
 - `ANTHROPIC_API_KEY` – API key used for Anthropic Claude
+- `CURL_VERIFY_SSL` – optional flag to disable SSL certificate verification when set to `false` (defaults to `true`)
 
 Example `config.local.php`:
 
@@ -22,6 +23,8 @@ define('DB_USER', 'my_user');
 define('DB_PASS', 'secret');
 define('GEMINI_API_KEY', 'your-api-key');
 define('ANTHROPIC_API_KEY', 'your-anthropic-key');
+// Optional: disable SSL certificate verification for debugging
+define('CURL_VERIFY_SSL', false);
 ```
 
 This file should **not** be committed to version control.

--- a/config.php
+++ b/config.php
@@ -25,6 +25,23 @@ if (!defined('GEMINI_API_KEY')) {
     }
 }
 
+// Whether cURL requests should verify SSL certificates.
+// Defaults to true for security. Set to false in `config.local.php` or via the
+// `CURL_VERIFY_SSL` environment variable if you need to bypass verification
+// during local development.
+if (!defined('CURL_VERIFY_SSL')) {
+    $verify = getenv('CURL_VERIFY_SSL');
+    if ($verify === false) {
+        $verify = true; // secure default
+    } else {
+        $verify = filter_var($verify, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($verify === null) {
+            $verify = true;
+        }
+    }
+    define('CURL_VERIFY_SSL', $verify);
+}
+
 function getDbConnection() {
     try {
         $pdo = new PDO('mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8', DB_USER, DB_PASS);

--- a/fetch_page_content.php
+++ b/fetch_page_content.php
@@ -18,8 +18,9 @@ function fetchPageContent($url) {
         curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
         curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+        $verifySsl = defined('CURL_VERIFY_SSL') ? CURL_VERIFY_SSL : true;
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verifySsl);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $verifySsl ? 2 : 0);
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36');
         curl_setopt($ch, CURLOPT_ENCODING, ""); // Automatyczna dekompresja gzip/deflate
         curl_setopt($ch, CURLOPT_HTTPHEADER, [


### PR DESCRIPTION
## Summary
- secure curl requests in `fetch_page_content.php`
- allow disabling SSL verification through `CURL_VERIFY_SSL` constant
- document the new option in `README`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68553bd89340833388558c1d44c88bf9