### PR TITLE
Implement session regeneration on login

### DIFF
--- a/login.php
+++ b/login.php
@@ -31,6 +31,8 @@ if ($_POST) {
         $user = $stmt->fetch();
         
         if ($user && password_verify($password, $user['password'])) {
+            // Regenerate session ID to mitigate session fixation attacks
+            session_regenerate_id(true);
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['user_email'] = $user['email'];
             $_SESSION['user_role'] = $user['role'];


### PR DESCRIPTION
## Summary
- regenerate the PHP session ID when users successfully login to prevent fixation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68553ce4b22c8333873e0dfa01bfb0c8