### PR TITLE
Fix duplicate task listings

### DIFF
--- a/tasks.php
+++ b/tasks.php
@@ -218,6 +218,8 @@ foreach ($tasks as &$task) {
         $task['status'] = $new_status;
     }
 }
+// Clear reference to avoid accidental modification in later loops
+unset($task);
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- prevent reference-induced array corruption when listing tasks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850742cb2f483338fb8af6faa28ba7a